### PR TITLE
Add pin translation for ATtinyX5

### DIFF
--- a/src/Capacitor.cpp
+++ b/src/Capacitor.cpp
@@ -75,7 +75,7 @@ float Capacitor::Measure()
     float capacitance;
 	
 #if defined(__AVR_ATtinyX5__)
-    pinMode(analogInputToDigitalPin(_inPin), INPUT);  // Rising high edge on OUT_PIN
+    pinMode(analogInputToDigitalPin(_inPin-A0), INPUT);  // Rising high edge on OUT_PIN
 #else
     pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
 #endif
@@ -85,7 +85,7 @@ float Capacitor::Measure()
 
     digitalWrite(_outPin, LOW);
 #if defined(__AVR_ATtinyX5__)
-    pinMode(analogInputToDigitalPin(_inPin), OUTPUT); // Clear everything for next measurement
+    pinMode(analogInputToDigitalPin(_inPin-A0), OUTPUT); // Clear everything for next measurement
 #else
     pinMode(_inPin, OUTPUT);                // Clear everything for next measurement
 #endif
@@ -112,7 +112,7 @@ float Capacitor::Measure()
         delayMicroseconds(200);             // Charge for about 200us
 
 #if defined(__AVR_ATtinyX5__)
-        pinMode(analogInputToDigitalPin(_inPin), INPUT);  // Stop charging
+        pinMode(analogInputToDigitalPin(_inPin-A0), INPUT);  // Stop charging
 #else
         pinMode(_inPin, INPUT);             // Stop charging
 #endif
@@ -130,14 +130,14 @@ float Capacitor::Measure()
             // Really big capacitor (>1uF)
             pinMode(_outPin, INPUT_PULLUP);
 #if defined(__AVR_ATtinyX5__)
-            pinMode(analogInputToDigitalPin(_inPin), OUTPUT); // Start charging again
+            pinMode(analogInputToDigitalPin(_inPin-A0), OUTPUT); // Start charging again
 #else
             pinMode(_inPin, OUTPUT);        // Start charging again
 #endif
             u3 = micros();
             delay(20);
 #if defined(__AVR_ATtinyX5__)
-            pinMode(analogInputToDigitalPin(_inPin), INPUT);  // Stop charging
+            pinMode(analogInputToDigitalPin(_inPin-A0), INPUT);  // Stop charging
 #else
             pinMode(_inPin, INPUT);             // Stop charging
 #endif
@@ -151,13 +151,13 @@ float Capacitor::Measure()
             while (adcVal < _maxAdcValue - _maxAdcValue / 8)
             {
 #if defined(__AVR_ATtinyX5__)
-                pinMode(analogInputToDigitalPin(_inPin), INPUT_PULLUP);  // Discharge slowly to about 0.6V
+                pinMode(analogInputToDigitalPin(_inPin-A0), INPUT_PULLUP);  // Discharge slowly to about 0.6V
 #else
                 pinMode(_inPin, INPUT_PULLUP);  // Discharge slowly to about 0.6V
 #endif
                 delay(5);
 #if defined(__AVR_ATtinyX5__)
-                pinMode(analogInputToDigitalPin(_inPin), INPUT);
+                pinMode(analogInputToDigitalPin(_inPin-A0), INPUT);
 #else
                 pinMode(_inPin, INPUT);
 #endif
@@ -167,13 +167,13 @@ float Capacitor::Measure()
         else
         {
 #if defined(__AVR_ATtinyX5__)
-            pinMode(analogInputToDigitalPin(_inPin), INPUT_PULLUP);  // Discharge slowly for a bit
+            pinMode(analogInputToDigitalPin(_inPin-A0), INPUT_PULLUP);  // Discharge slowly for a bit
 #else
             pinMode(_inPin, INPUT_PULLUP);  // Discharge slowly for a bit
 #endif
             delay(1);
 #if defined(__AVR_ATtinyX5__)
-            pinMode(analogInputToDigitalPin(_inPin), INPUT);
+            pinMode(analogInputToDigitalPin(_inPin-A0), INPUT);
 #else
             pinMode(_inPin, INPUT);
 #endif
@@ -184,8 +184,8 @@ float Capacitor::Measure()
       
         digitalWrite(_outPin, LOW);           // Discharge remainder quickly
 #if defined(__AVR_ATtinyX5__)
-        digitalWrite(analogInputToDigitalPin(_inPin), LOW);
-        pinMode(analogInputToDigitalPin(_inPin), OUTPUT);
+        digitalWrite(analogInputToDigitalPin(_inPin-A0), LOW);
+        pinMode(analogInputToDigitalPin(_inPin-A0), OUTPUT);
 #else
         digitalWrite(_inPin, LOW);
         pinMode(_inPin, OUTPUT);

--- a/src/CapacitorLite.cpp
+++ b/src/CapacitorLite.cpp
@@ -65,23 +65,21 @@ unsigned int CapacitorLite::Measure()
 {
     long capacitance;
 
-    pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
-    digitalWrite(_outPin, HIGH);
 #if defined(__AVR_ATtinyX5__)
-    int val = 0;
-    switch(_inPin)
-	{
-		case 2: val = analogRead(1); break;
-		case 3: val = analogRead(3); break;
-		case 4: val = analogRead(2); break;
-		case 5: val = analogRead(0); break;
-		default: analogRead(_inPin);
-	}
+        pinMode(analogInputToDigitalPin(_inPin), INPUT);  // Convert AnalogPin to Digital for ATTinyX5 chips
 #else
-	int val = analogRead(_inPin);
+        pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
 #endif
+    digitalWrite(_outPin, HIGH);
+
+	int val = analogRead(_inPin);
+
     digitalWrite(_outPin, LOW);
-    pinMode(_inPin, OUTPUT);                // Clear everything for next measurement
+#if defined(__AVR_ATtinyX5__)
+    pinMode(analogInputToDigitalPin(_inPin), OUTPUT);  // Convert AnalogPin to Digital for ATTinyX5 chips, Clear everything for next measurement
+#else
+    pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
+#endif
 
     // Calculate result
     capacitance = (long)val * _inCapToGnd / (max(_maxAdcValue - val, 1));

--- a/src/CapacitorLite.cpp
+++ b/src/CapacitorLite.cpp
@@ -66,7 +66,7 @@ unsigned int CapacitorLite::Measure()
     long capacitance;
 
 #if defined(__AVR_ATtinyX5__)
-        pinMode(analogInputToDigitalPin(_inPin), INPUT);  // Convert AnalogPin to Digital for ATTinyX5 chips
+        pinMode(analogInputToDigitalPin(_inPin-A0), INPUT);  // Convert AnalogPin to Digital for ATTinyX5 chips
 #else
         pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
 #endif
@@ -76,7 +76,7 @@ unsigned int CapacitorLite::Measure()
 
     digitalWrite(_outPin, LOW);
 #if defined(__AVR_ATtinyX5__)
-    pinMode(analogInputToDigitalPin(_inPin), OUTPUT);  // Convert AnalogPin to Digital for ATTinyX5 chips, Clear everything for next measurement
+    pinMode(analogInputToDigitalPin(_inPin-A0), OUTPUT);  // Convert AnalogPin to Digital for ATTinyX5 chips, Clear everything for next measurement
 #else
     pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
 #endif

--- a/src/CapacitorLite.cpp
+++ b/src/CapacitorLite.cpp
@@ -19,6 +19,8 @@
     #define STRAY_CAP (2630);
 #elif defined(__AVR_ATmega32U4__)
     #define STRAY_CAP (3600);
+#elif defined(__AVR_ATtinyX5__)
+    #define STRAY_CAP (1900);
 #else
     #define STRAY_CAP (2448);
 #endif
@@ -65,7 +67,19 @@ unsigned int CapacitorLite::Measure()
 
     pinMode(_inPin, INPUT);                 // Rising high edge on OUT_PIN
     digitalWrite(_outPin, HIGH);
-    int val = analogRead(_inPin);
+#if defined(__AVR_ATtinyX5__)
+    int val = 0;
+    switch(_inPin)
+	{
+		case 2: val = analogRead(1); break;
+		case 3: val = analogRead(3); break;
+		case 4: val = analogRead(2); break;
+		case 5: val = analogRead(0); break;
+		default: analogRead(_inPin);
+	}
+#else
+	int val = analogRead(_inPin);
+#endif
     digitalWrite(_outPin, LOW);
     pinMode(_inPin, OUTPUT);                // Clear everything for next measurement
 


### PR DESCRIPTION
Hello,
  I've started to use your library to make soil moisture sensors based of the capacitance of the soil. It's looking very promising and you've made the library very easy to use; even at low voltage @ 1Mhz on the ATTiny85. Thank you for your work.

  On the ATTiny25/45/85 chips, the analog and aigital pin definitions don't match. However, in the `Capacitor.cpp::Measure()` and `CapacitorLite::Measure()` functions, you address the `_inPin` with both digital and analog functions, causing the library to fail.
*  It looks like the ATTiny24/44/84 use the same definition for digital and analog pins, so no changes are needed.

  To fix this, I've added:
    - a switch statement to either read or lookup the correct analog pin from the digital `inPin`.
    - `STARY_CAP` and `R_PULLUP` values for the ATtinyX5 (25,45,85) series that worked for my chip.

  The digital pin for the ATTiny chip should be provided to the library, not the Analog pin.

  Please note that I've mainly been testing with the CapacitorLite library and only with the ATTiny84 and ATMega328. (I don't have other ATTiny chips to test on.)
  Please check to confirm that I haven't broken any of your coding standards or the functionality for other chips.